### PR TITLE
Bump ark to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ exclude = [
 ]
 
 [dependencies]
-ark-bn254 = "0.4.0"
-ark-ec = {version = "0.4.2", features = ["parallel"]}
-ark-ff = {version = "0.4.2", features = ["parallel"]}
-ark-serialize = "0.4.2"
-ark-std = {version = "0.4.0", features = ["parallel"]}
+ark-bn254 = "0.5.0-alpha.0"
+ark-ec = {version = "0.5.0-alpha.0", features = ["parallel"]}
+ark-ff = {version = "0.5.0-alpha.0", features = ["parallel"]}
+ark-serialize = "0.5.0-alpha.0"
+ark-std = {version = "0.5.0-alpha.0", features = ["parallel"]}
 directories = "5.0.1"
 hex-literal = "0.4.1"
 rand = "0.8.5"
@@ -28,7 +28,7 @@ num-bigint = "0.4"
 rayon = "^1.5"
 num-traits = "0.2"
 byteorder = "1.4"
-ark-poly = {version = "0.4.2", features = ["parallel"]}
+ark-poly = {version = "0.5.0-alpha.0", features = ["parallel"]}
 crossbeam-channel = "0.5"
 num_cpus = "1.13.0"
 sys-info = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ exclude = [
 ]
 
 [dependencies]
-ark-bn254 = "0.5.0-alpha.0"
-ark-ec = {version = "0.5.0-alpha.0", features = ["parallel"]}
-ark-ff = {version = "0.5.0-alpha.0", features = ["parallel"]}
-ark-serialize = "0.5.0-alpha.0"
-ark-std = {version = "0.5.0-alpha.0", features = ["parallel"]}
+ark-bn254 = "0.5.0"
+ark-ec = {version = "0.5.0", features = ["parallel"]}
+ark-ff = {version = "0.5.0", features = ["parallel"]}
+ark-serialize = "0.5.0"
+ark-std = {version = "0.5.0", features = ["parallel"]}
 directories = "5.0.1"
 hex-literal = "0.4.1"
 rand = "0.8.5"
@@ -28,7 +28,7 @@ num-bigint = "0.4"
 rayon = "^1.5"
 num-traits = "0.2"
 byteorder = "1.4"
-ark-poly = {version = "0.5.0-alpha.0", features = ["parallel"]}
+ark-poly = {version = "0.5.0", features = ["parallel"]}
 crossbeam-channel = "0.5"
 num_cpus = "1.13.0"
 sys-info = "0.9"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,5 @@
-nightly-2024-08-01
+[toolchain]
+channel = '1.75'
+profile = 'minimal'
+components = ['clippy', 'rustfmt']
+targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-gnu", "wasm32-unknown-unknown", "aarch64-apple-darwin"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,1 @@
-[toolchain]
-channel = '1.74'
-profile = 'minimal'
-components = ['clippy', 'rustfmt']
-targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-gnu", "wasm32-unknown-unknown", "aarch64-apple-darwin"]
+nightly-2024-08-01

--- a/src/arith.rs
+++ b/src/arith.rs
@@ -124,8 +124,8 @@ pub fn madd2(a: u64, b: u64, c: u64, d: u64) -> (u64, u64) {
 #[test]
 fn test_montgomery_reduce() {
     use ark_bn254::Fr;
-    use ark_ff::Field;
     use ark_ec::AdditiveGroup;
+    use ark_ff::Field;
 
     let inv = Fq::from(<Fr as PrimeField>::MODULUS)
         .neg_in_place()

--- a/src/arith.rs
+++ b/src/arith.rs
@@ -125,6 +125,7 @@ pub fn madd2(a: u64, b: u64, c: u64, d: u64) -> (u64, u64) {
 fn test_montgomery_reduce() {
     use ark_bn254::Fr;
     use ark_ff::Field;
+    use ark_ec::AdditiveGroup;
 
     let inv = Fq::from(<Fr as PrimeField>::MODULUS)
         .neg_in_place()

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -19,6 +19,7 @@ use crate::{
     },
     traits::ReadPointFromBytes,
 };
+use ark_ec::AdditiveGroup;
 
 pub fn blob_to_polynomial(blob: &[u8]) -> Vec<Fr> {
     to_fr_array(blob)


### PR DESCRIPTION
This PR is related to the work we are doing at integrating `EigenDA` with `Zksync`. To achieve this, we need to upgrade the version of the arkworks related libraries (`ark-bn254`, `ark-ec`, `ark-ff`, `ark-serialize`, `ark-std`, `ark-poly`) to 0.5.0 and change the Rust toolchain from 1.74 to 1.75 since they require a newer compiler version.