### PR TITLE
style!: cleanup blob struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Linting can be triggered via running `cargo clippy --all --manifest-path Cargo.t
 
 ## Quick Start
 
-1. Check the test in `test_compute_kzg_proof` function to see the end to end usage of the library for quick start.
+See the `test_compute_kzg_proof` function in [./tests/kzg_test.rs](./tests/kzg_test.rs#) for an end to end usage of the library.
 
 ## Requirements
 
-1. SRS points required are in the same format as provided by the EigenDA.
-2. Commiting is performed in lagrange format. The required IFFT is done within the function and is not required to be performed separately.
-3. For proof generation, the data is treated as evaluation of polynomial. The required (i)FFT is performed by the compute function and is not required to be performed separately.
+1. SRS points required are in the same format as provided by EigenDA.
+2. Committing is performed in Lagrange format. The required IFFT is done within the function and is not required to be performed separately.
+3. For proof generation, the data is treated as evaluation of polynomial. The required (I)FFT is performed by the compute function and is not required to be performed separately.
 
 ## Function Reference
 

--- a/benches/bench_kzg_commit.rs
+++ b/benches/bench_kzg_commit.rs
@@ -16,7 +16,7 @@ fn bench_kzg_commit(c: &mut Criterion) {
 
     c.bench_function("bench_kzg_commit_10000", |b| {
         let random_blob: Vec<u8> = (0..10000).map(|_| rng.gen_range(32..=126) as u8).collect();
-        let input = Blob::from_bytes_and_pad(&random_blob);
+        let input = Blob::from_raw_data(&random_blob);
         let input_poly = input
             .to_polynomial(PolynomialFormat::InCoefficientForm)
             .unwrap();
@@ -27,7 +27,7 @@ fn bench_kzg_commit(c: &mut Criterion) {
 
     c.bench_function("bench_kzg_commit_30000", |b| {
         let random_blob: Vec<u8> = (0..30000).map(|_| rng.gen_range(32..=126) as u8).collect();
-        let input = Blob::from_bytes_and_pad(&random_blob);
+        let input = Blob::from_raw_data(&random_blob);
         let input_poly = input
             .to_polynomial(PolynomialFormat::InCoefficientForm)
             .unwrap();
@@ -38,7 +38,7 @@ fn bench_kzg_commit(c: &mut Criterion) {
 
     c.bench_function("bench_kzg_commit_50000", |b| {
         let random_blob: Vec<u8> = (0..50000).map(|_| rng.gen_range(32..=126) as u8).collect();
-        let input = Blob::from_bytes_and_pad(&random_blob);
+        let input = Blob::from_raw_data(&random_blob);
         let input_poly = input
             .to_polynomial(PolynomialFormat::InCoefficientForm)
             .unwrap();

--- a/benches/bench_kzg_commit_large_blobs.rs
+++ b/benches/bench_kzg_commit_large_blobs.rs
@@ -18,7 +18,7 @@ fn bench_kzg_commit(c: &mut Criterion) {
         let random_blob: Vec<u8> = (0..8000000)
             .map(|_| rng.gen_range(32..=126) as u8)
             .collect();
-        let input = Blob::from_bytes_and_pad(&random_blob);
+        let input = Blob::from_raw_data(&random_blob);
         let input_poly = input
             .to_polynomial(PolynomialFormat::InCoefficientForm)
             .unwrap();
@@ -31,7 +31,7 @@ fn bench_kzg_commit(c: &mut Criterion) {
         let random_blob: Vec<u8> = (0..16_252_000)
             .map(|_| rng.gen_range(32..=126) as u8)
             .collect();
-        let input = Blob::from_bytes_and_pad(&random_blob);
+        let input = Blob::from_raw_data(&random_blob);
         let input_poly = input
             .to_polynomial(PolynomialFormat::InCoefficientForm)
             .unwrap();

--- a/benches/bench_kzg_proof.rs
+++ b/benches/bench_kzg_proof.rs
@@ -16,7 +16,7 @@ fn bench_kzg_proof(c: &mut Criterion) {
 
     c.bench_function("bench_kzg_proof_10000", |b| {
         let random_blob: Vec<u8> = (0..10000).map(|_| rng.gen_range(32..=126) as u8).collect();
-        let input = Blob::from_bytes_and_pad(&random_blob);
+        let input = Blob::from_raw_data(&random_blob);
         let input_poly = input
             .to_polynomial(PolynomialFormat::InCoefficientForm)
             .unwrap();
@@ -32,7 +32,7 @@ fn bench_kzg_proof(c: &mut Criterion) {
 
     c.bench_function("bench_kzg_proof_30000", |b| {
         let random_blob: Vec<u8> = (0..30000).map(|_| rng.gen_range(32..=126) as u8).collect();
-        let input = Blob::from_bytes_and_pad(&random_blob);
+        let input = Blob::from_raw_data(&random_blob);
         let input_poly = input
             .to_polynomial(PolynomialFormat::InCoefficientForm)
             .unwrap();
@@ -48,7 +48,7 @@ fn bench_kzg_proof(c: &mut Criterion) {
 
     c.bench_function("bench_kzg_proof_50000", |b| {
         let random_blob: Vec<u8> = (0..50000).map(|_| rng.gen_range(32..=126) as u8).collect();
-        let input = Blob::from_bytes_and_pad(&random_blob);
+        let input = Blob::from_raw_data(&random_blob);
         let input_poly = input
             .to_polynomial(PolynomialFormat::InCoefficientForm)
             .unwrap();

--- a/benches/bench_kzg_verify.rs
+++ b/benches/bench_kzg_verify.rs
@@ -16,7 +16,7 @@ fn bench_kzg_verify(c: &mut Criterion) {
 
     c.bench_function("bench_kzg_verify_10000", |b| {
         let random_blob: Vec<u8> = (0..10000).map(|_| rng.gen_range(32..=126) as u8).collect();
-        let input = Blob::from_bytes_and_pad(&random_blob);
+        let input = Blob::from_raw_data(&random_blob);
         let input_poly = input
             .to_polynomial(PolynomialFormat::InCoefficientForm)
             .unwrap();
@@ -35,7 +35,7 @@ fn bench_kzg_verify(c: &mut Criterion) {
 
     c.bench_function("bench_kzg_verify_30000", |b| {
         let random_blob: Vec<u8> = (0..30000).map(|_| rng.gen_range(32..=126) as u8).collect();
-        let input = Blob::from_bytes_and_pad(&random_blob);
+        let input = Blob::from_raw_data(&random_blob);
         let input_poly = input
             .to_polynomial(PolynomialFormat::InCoefficientForm)
             .unwrap();
@@ -54,7 +54,7 @@ fn bench_kzg_verify(c: &mut Criterion) {
 
     c.bench_function("bench_kzg_verify_50000", |b| {
         let random_blob: Vec<u8> = (0..50000).map(|_| rng.gen_range(32..=126) as u8).collect();
-        let input = Blob::from_bytes_and_pad(&random_blob);
+        let input = Blob::from_raw_data(&random_blob);
         let input_poly = input
             .to_polynomial(PolynomialFormat::InCoefficientForm)
             .unwrap();

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -5,63 +5,45 @@ use crate::{
 };
 
 /// A blob which is Eigen DA spec aligned.
+/// TODO: we should probably move to a transparent repr like
+///       https://docs.rs/alloy-primitives/latest/alloy_primitives/struct.FixedBytes.html
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Blob {
     blob_data: Vec<u8>,
-    is_padded: bool,
-    length_after_padding: usize,
 }
 
 impl Blob {
-    /// Creates a new `Blob` from the given data.
-    pub fn new(blob_data: Vec<u8>) -> Self {
-        Blob {
-            blob_data,
-            is_padded: false,
-            length_after_padding: 0,
-        }
-    }
-
-    pub fn get_length_after_padding(&self) -> usize {
-        self.length_after_padding
-    }
-
-    /// Creates a new `Blob` from the given data.
-    pub fn is_padded(&self) -> bool {
-        self.is_padded
-    }
-
-    /// Creates a new `Blob` from the provided byte slice and pads it according
-    /// to DA specs.
-    pub fn from_bytes_and_pad(input: &[u8]) -> Self {
-        let padded_input = helpers::convert_by_padding_empty_byte(input);
-        let length_after_padding = padded_input.len();
-        Blob {
-            blob_data: padded_input,
-            is_padded: true,
-            length_after_padding,
-        }
-    }
-
-    /// Creates a new `Blob` from the provided byte slice and assumes it's
-    /// already padded according to DA specs.
+    /// Creates a new `Blob` from the given blob_data.
+    /// blob_data should already be padded according to DA specs, meaning
+    /// that it contains bn254 field elements. Otherwise, use [`Blob::from_raw_data`].
+    ///
     /// WARNING: This function does not check if the bytes are modulo bn254
     /// if the data has 32 byte segments exceeding the modulo of the field
     /// then the bytes will be modded by the order of the field and the data
-    /// will be transformed incorrectly
-    pub fn from_padded_bytes_unchecked(input: &[u8]) -> Self {
-        let length_after_padding = input.len();
-
+    /// will be transformed incorrectly.
+    /// TODO: we should check that the bytes are correct and return an error instead of
+    ///       relying on the users reading this documentation.
+    pub fn new(blob_data: &[u8]) -> Self {
         Blob {
-            blob_data: input.to_vec(),
-            is_padded: true,
-            length_after_padding,
+            blob_data: blob_data.to_vec(),
         }
     }
 
+    /// Creates a new `Blob` from the provided raw_data byte slice and pads it according
+    /// to DA specs. If the data is already padded, use [`Blob::new`] instead.
+    pub fn from_raw_data(raw_data: &[u8]) -> Self {
+        let blob_data = helpers::convert_by_padding_empty_byte(raw_data);
+        Blob { blob_data }
+    }
+
+    /// Returns the raw data of the blob, removing any padding added by [`Blob::from_raw_data`].
+    pub fn to_raw_data(&self) -> Vec<u8> {
+        helpers::remove_empty_byte_from_padded_bytes_unchecked(&self.blob_data)
+    }
+
     /// Returns the blob data
-    pub fn get_blob_data(&self) -> Vec<u8> {
-        self.blob_data.clone()
+    pub fn data(&self) -> &[u8] {
+        &self.blob_data
     }
 
     /// Returns the length of the data in the blob.
@@ -74,40 +56,23 @@ impl Blob {
         self.blob_data.is_empty()
     }
 
-    /// Pads the blob data in-place if it is not already padded.
-    pub fn pad_data(&mut self) -> Result<(), BlobError> {
-        if self.is_padded {
-            Err(BlobError::AlreadyPaddedError)
-        } else {
-            self.blob_data = helpers::convert_by_padding_empty_byte(&self.blob_data);
-            self.is_padded = true;
-            self.length_after_padding = self.blob_data.len();
-            Ok(())
-        }
-    }
-
-    /// Removes padding from the blob data if it is padded.
-    pub fn remove_padding(&mut self) -> Result<(), BlobError> {
-        if !self.is_padded {
-            Err(BlobError::NotPaddedError)
-        } else {
-            self.blob_data =
-                helpers::remove_empty_byte_from_padded_bytes_unchecked(&self.blob_data);
-            self.is_padded = false;
-            self.length_after_padding = 0;
-            Ok(())
-        }
-    }
-
     /// Converts the blob data to a `Polynomial` if the data is padded.
     pub fn to_polynomial(&self, form: PolynomialFormat) -> Result<Polynomial, BlobError> {
-        if !self.is_padded {
-            Err(BlobError::NotPaddedError)
-        } else {
-            let fr_vec = helpers::to_fr_array(&self.blob_data);
-            let poly = Polynomial::new(&fr_vec, self.length_after_padding, form)
-                .map_err(|err| BlobError::GenericError(err.to_string()))?;
-            Ok(poly)
-        }
+        let fr_vec = helpers::to_fr_array(&self.blob_data);
+        let poly = Polynomial::new(&fr_vec, self.len(), form)
+            .map_err(|err| BlobError::GenericError(err.to_string()))?;
+        Ok(poly)
+    }
+}
+
+impl From<Vec<u8>> for Blob {
+    fn from(blob_data: Vec<u8>) -> Self {
+        Blob { blob_data }
+    }
+}
+
+impl From<Blob> for Vec<u8> {
+    fn from(blob: Blob) -> Self {
+        blob.blob_data
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,16 +2,12 @@ use std::{error::Error, fmt};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum BlobError {
-    NotPaddedError,
-    AlreadyPaddedError,
     GenericError(String),
 }
 
 impl fmt::Display for BlobError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            BlobError::NotPaddedError => write!(f, "tried to execute on non padded blob"),
-            BlobError::AlreadyPaddedError => write!(f, "tried to execute on already padded blob"),
             BlobError::GenericError(ref msg) => write!(f, "generic error: {}", msg),
         }
     }

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use rust_kzg_bn254::errors::{BlobError, KzgError, PolynomialError};
+    use rust_kzg_bn254::errors::{KzgError, PolynomialError};
 
     #[test]
     fn test_polynomial_error_serialization_from_string() {
@@ -86,41 +86,5 @@ mod tests {
         let error3 = KzgError::SerializationError(String::from("different error"));
         assert_eq!(error1, error2);
         assert_ne!(error1, error3);
-    }
-
-    #[test]
-    fn test_not_padded_error_display() {
-        let error = BlobError::NotPaddedError;
-        assert_eq!(format!("{}", error), "tried to execute on non padded blob");
-    }
-
-    #[test]
-    fn test_already_padded_error_display() {
-        let error = BlobError::AlreadyPaddedError;
-        assert_eq!(
-            format!("{}", error),
-            "tried to execute on already padded blob"
-        );
-    }
-
-    #[test]
-    fn test_blob_error_equality() {
-        let error1 = BlobError::NotPaddedError;
-        let error2 = BlobError::NotPaddedError;
-        let error3 = BlobError::AlreadyPaddedError;
-        let error4 = BlobError::GenericError("test".to_string());
-
-        assert_eq!(error1, error2);
-        assert_ne!(error1, error3);
-        assert_ne!(error1, error4);
-    }
-
-    #[test]
-    fn test_blob_generic_error() {
-        let error1 = BlobError::GenericError(String::from("error"));
-        let error3 = BlobError::GenericError(String::from("error"));
-        let error2 = BlobError::NotPaddedError;
-        assert_eq!(error1, error3);
-        assert_ne!(error1, error2);
     }
 }

--- a/tests/kzg_test.rs
+++ b/tests/kzg_test.rs
@@ -168,12 +168,12 @@ mod tests {
                 .map(|_| rng.gen_range(32..=126) as u8)
                 .collect();
 
-            let input = Blob::from_bytes_and_pad(&random_blob);
+            let input = Blob::from_raw_data(&random_blob);
             kzg_clone1
                 .data_setup_custom(1, input.len().try_into().unwrap())
                 .unwrap();
             kzg_clone2
-                .calculate_roots_of_unity(input.get_length_after_padding().try_into().unwrap())
+                .calculate_roots_of_unity(input.len().try_into().unwrap())
                 .unwrap();
 
             let polynomial_input = input
@@ -194,7 +194,7 @@ mod tests {
     fn test_blob_to_kzg_commitment() {
         use ark_bn254::Fq;
 
-        let blob = Blob::from_bytes_and_pad(GETTYSBURG_ADDRESS_BYTES);
+        let blob = Blob::from_raw_data(GETTYSBURG_ADDRESS_BYTES);
         let fn_output = KZG_3000
             .blob_to_kzg_commitment(&blob, PolynomialFormat::InCoefficientForm)
             .unwrap();
@@ -225,7 +225,7 @@ mod tests {
                 .collect();
             println!("generating blob of length is {}", blob_length);
 
-            let input = Blob::from_bytes_and_pad(&random_blob);
+            let input = Blob::from_raw_data(&random_blob);
             let input_poly = input
                 .to_polynomial(PolynomialFormat::InCoefficientForm)
                 .unwrap();
@@ -267,7 +267,7 @@ mod tests {
 
         let mut kzg = KZG_INSTANCE.clone();
 
-        let input = Blob::from_bytes_and_pad(GETTYSBURG_ADDRESS_BYTES);
+        let input = Blob::from_raw_data(GETTYSBURG_ADDRESS_BYTES);
         let input_poly = input
             .to_polynomial(PolynomialFormat::InCoefficientForm)
             .unwrap();

--- a/tests/polynomial_test.rs
+++ b/tests/polynomial_test.rs
@@ -26,7 +26,7 @@ mod tests {
 
     #[test]
     fn test_to_fr_array() {
-        let mut blob = Blob::from_bytes_and_pad(
+        let blob = Blob::from_raw_data(
             vec![
                 42, 212, 238, 227, 192, 237, 178, 128, 19, 108, 50, 204, 87, 81, 63, 120, 232, 27,
                 116, 108, 74, 168, 109, 84, 89, 9, 6, 233, 144, 200, 125, 40,
@@ -38,13 +38,12 @@ mod tests {
             .unwrap();
         assert_eq!(
             poly.to_bytes_be(),
-            blob.get_blob_data(),
+            blob.data(),
             "should be deserialized properly"
         );
 
-        blob.remove_padding().unwrap();
         assert_eq!(
-            blob.get_blob_data(),
+            blob.to_raw_data(),
             vec![
                 42, 212, 238, 227, 192, 237, 178, 128, 19, 108, 50, 204, 87, 81, 63, 120, 232, 27,
                 116, 108, 74, 168, 109, 84, 89, 9, 6, 233, 144, 200, 125, 40
@@ -52,27 +51,21 @@ mod tests {
             "should be deserialized properly"
         );
 
-        let mut long_blob = Blob::from_bytes_and_pad(GETTYSBURG_ADDRESS_BYTES);
+        let long_blob = Blob::from_raw_data(GETTYSBURG_ADDRESS_BYTES);
         let long_poly = long_blob
             .to_polynomial(PolynomialFormat::InCoefficientForm)
             .unwrap();
         // let ga_converted_fr = to_fr_array(&ga_converted);
         assert_eq!(
-            long_blob.get_blob_data(),
-            long_poly.to_bytes_be(),
-            "should be deserialized properly"
-        );
-        long_blob.remove_padding().unwrap();
-        assert_eq!(
-            long_blob.get_blob_data(),
-            GETTYSBURG_ADDRESS_BYTES,
+            long_blob.data(),
+            &long_poly.to_bytes_be(),
             "should be deserialized properly"
         );
     }
 
     #[test]
     fn test_transform_form() {
-        let blob = Blob::from_bytes_and_pad(
+        let blob = Blob::from_raw_data(
             vec![
                 42, 212, 238, 227, 192, 237, 178, 128, 19, 108, 50, 204, 87, 81, 63, 120, 232, 27,
                 116, 108, 74, 168, 109, 84, 89, 9, 6, 233, 144, 200, 125, 40,
@@ -107,12 +100,12 @@ mod tests {
             "should be in coefficient form"
         );
         assert_eq!(
-            poly.to_bytes_be(),
-            blob.get_blob_data(),
+            &poly.to_bytes_be(),
+            blob.data(),
             "start and finish bytes should be the same"
         );
 
-        let long_blob = Blob::from_bytes_and_pad(GETTYSBURG_ADDRESS_BYTES);
+        let long_blob = Blob::from_raw_data(GETTYSBURG_ADDRESS_BYTES);
         let mut long_poly = long_blob
             .to_polynomial(PolynomialFormat::InCoefficientForm)
             .unwrap();
@@ -142,8 +135,8 @@ mod tests {
         );
 
         assert_eq!(
-            long_blob.get_blob_data(),
-            long_poly.to_bytes_be(),
+            long_blob.data(),
+            &long_poly.to_bytes_be(),
             "start and finish bytes should be the same"
         );
     }


### PR DESCRIPTION
Fixes #14 

Contains some breaking api changes.
Also fixed the tests syntactically only, did not think very deeply about their semantics, so hopefully nothing breaks (doubt it though because this new API is much much simpler: blobs are no longer mutable and stateful).

@epociask tagging you since I think you are using this in nitro. Should be a pretty simple change to update to this new API.