### PR TITLE
moving to 1.75 based on internal convo

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
       run: cargo test --verbose
     - name: 32bit compilation test
       run: cargo build --target i686-unknown-linux-gnu --verbose
-    - name: Running tests under 32bit architecture
-      run: cargo install cross && cross test --target i686-unknown-linux-gnu --verbose
+    # - name: Running tests under 32bit architecture
+    #   run: cargo install cross && cross test --target i686-unknown-linux-gnu --verbose
 
     

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
       run: cargo test --verbose
     - name: 32bit compilation test
       run: cargo build --target i686-unknown-linux-gnu --verbose
-    # - name: Running tests under 32bit architecture
-    #   run: cargo install cross && cross test --target i686-unknown-linux-gnu --verbose
+    - name: Running tests under 32bit architecture
+      run: cargo install cross@0.1.16 && cross test --target i686-unknown-linux-gnu --verbose
 
     

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ thiserror = "2.0.11"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.75"
 repository = "https://github.com/Layr-Labs/rust-kzg-bn254"
 homepage = ""
 license-file = "LICENSE"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = '1.81'
+channel = '1.75'
 profile = 'minimal'
 components = ['clippy', 'rustfmt']
 targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "i686-unknown-linux-gnu"]


### PR DESCRIPTION
cross 0.1.16 doesn't have the offending library which requires 1.81 rust version.
moving to 1.75 so its compatible with arbitrum and risc0.