### PR TITLE
release 0.1.1

### DIFF
--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-kzg-bn254-prover"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "This library offers a set of functions for generating and interacting with bn254 KZG commitments and proofs in rust, with the motivation of supporting fraud and validity proof logic in EigenDA rollup integrations."

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-kzg-bn254-verifier"
-version = "0.1.0"
+version = "0.1.1"
 description = "This library offers a set of functions for verifying KZG commitments and proofs in bn254, with the motivation of supporting fraud and validity proof logic in EigenDA rollup integrations."
 license-file.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Releasing prover and verifier version of 0.1.1. Primitives already is on 0.1.1 and is latest.