### PR TITLE
chore: update rust.yml + readme to better document dependencies

### DIFF
--- a/.github/workflows/crates-release-prod.yml
+++ b/.github/workflows/crates-release-prod.yml
@@ -1,3 +1,4 @@
+name: crate-release-prod
 on:
   workflow_dispatch:
   

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,6 @@ jobs:
     - name: 32bit compilation test
       run: cargo build --target i686-unknown-linux-gnu --verbose
     - name: Running tests under 32bit architecture
-      run: cargo update half@2.5.0 --precise 2.4.1 && cargo install cross@0.1.16 && cross test --target i686-unknown-linux-gnu --verbose
+      run: cargo install cross@0.1.16 && cross test --target i686-unknown-linux-gnu --verbose
 
     

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+
     steps:
+    - uses: step-security/harden-runner@446798f8213ac2e75931c1b0769676d927801858 # v2.10.3
+      with:
+        egress-policy: audit
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - name: Build
       run: cargo build --verbose
@@ -21,8 +25,11 @@ jobs:
       run: cargo fmt --all -- --check
     - name: Clippy Format test
       run: cargo clippy --all --manifest-path Cargo.toml -- -D warnings
+    # Refer to readme as to why this is done.
+    - name: Update cargo lock with compatible `half` library at version 2.4.1.
+      run: cargo update half@2.5.0 --precise 2.4.1 
     - name: Run tests
-      run: cargo update half@2.5.0 --precise 2.4.1 && cargo test --verbose
+      run: cargo test --verbose
     - name: 32bit compilation test
       run: cargo build --target i686-unknown-linux-gnu --verbose
     - name: Running tests under 32bit architecture

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,10 +22,10 @@ jobs:
     - name: Clippy Format test
       run: cargo clippy --all --manifest-path Cargo.toml -- -D warnings
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo update half@2.5.0 --precise 2.4.1 && cargo test --verbose
     - name: 32bit compilation test
       run: cargo build --target i686-unknown-linux-gnu --verbose
     - name: Running tests under 32bit architecture
-      run: cargo install cross@0.1.16 && cross test --target i686-unknown-linux-gnu --verbose
+      run: cargo update half@2.5.0 --precise 2.4.1 && cargo install cross@0.1.16 && cross test --target i686-unknown-linux-gnu --verbose
 
     

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,16 @@ jobs:
     steps:
     - uses: step-security/harden-runner@446798f8213ac2e75931c1b0769676d927801858 # v2.10.3
       with:
-        egress-policy: audit
+        disable-sudo: true
+        egress-policy: block
+        allowed-endpoints: >
+          auth.docker.io:443
+          github.com:443
+          index.crates.io:443
+          production.cloudflare.docker.com:443
+          registry-1.docker.io:443
+          static.crates.io:443
+          static.rust-lang.org:443
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - name: Build
       run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,7 +40,7 @@ jobs:
       run: cargo clippy --all --manifest-path Cargo.toml -- -D warnings
     # Refer to readme as to why this is done.
     - name: Update cargo lock with compatible `half` library at version 2.4.1.
-      run: cargo update half@2.5.0 --precise 2.4.1 
+      run: cargo update half --precise 2.4.1 
     - name: Run tests
       run: cargo test --verbose
     - name: 32bit compilation test

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cargo bench
 
 ### Downstream Dependencies
 1. Arbitrum Nitro uses rust 1.78
-2. RiscZero ZKVM uses 1.85
+2. RiscZero ZKVM uses [1.85](https://github.com/risc0/risc0/blob/545e967bcf4fc28276e02181915febe12a1a9880/rust-toolchain.toml#L2)
 3. SP1 ZKVM uses [1.79](https://github.com/succinctlabs/sp1/blob/81757da015939d8a851d909e8c3df14bdc3b030d/Cargo.toml#L5)
 
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# rust-kzg-bn254
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A Rust implementation of KZG polynomial commitments using the BN254 elliptic curve, designed for the Ethereum ecosystem and EigenDA rollup integrations.
+
+## Overview
+
+The Kate-Zaverucha-Goldberg (KZG) polynomial commitment scheme allows for efficient proofs that a specific value exists in a polynomial at a given point, without revealing the entire polynomial. This implementation specifically targets the BN254 elliptic curve pairing, which is widely used in various blockchain applications.
+
+## Crates
+
+This repository is organized as a Rust workspace with three main crates:
+
+### [rust-kzg-bn254-primitives](./primitives)
+
+[![Docs](https://docs.rs/rust-kzg-bn254-primitives/badge.svg)](https://docs.rs/rust-kzg-bn254-primitives/latest/rust_kzg_bn254_primitives/)
+[![Crate](https://img.shields.io/crates/v/rust-kzg-bn254-primitives.svg)](https://crates.io/crates/rust-kzg-bn254-primitives)
+
+Provides the fundamental data structures and operations:
+- `Blob`: Data representation with conversion methods
+- `Polynomial`: Support for both evaluation and coefficient forms
+- Various arithmetic and helper functions
+
+### [rust-kzg-bn254-prover](./prover)
+
+[![Docs](https://docs.rs/rust-kzg-bn254-prover/badge.svg)](https://docs.rs/rust-kzg-bn254-prover/latest/rust_kzg_bn254_prover/)
+[![Crate](https://img.shields.io/crates/v/rust-kzg-bn254-prover.svg)](https://crates.io/crates/rust-kzg-bn254-prover)
+
+Implements KZG commitment and proof generation:
+- `KZG`: Main struct for creating commitments and generating proofs
+- `SRS`: Structured Reference String handling
+- Optimized parallel FFT implementations
+
+### [rust-kzg-bn254-verifier](./verifier)
+
+[![Docs](https://docs.rs/rust-kzg-bn254-verifier/badge.svg)](https://docs.rs/rust-kzg-bn254-verifier/latest/rust_kzg_bn254_verifier/)
+[![Crate](https://img.shields.io/crates/v/rust-kzg-bn254-verifier.svg)](https://crates.io/crates/rust-kzg-bn254-verifier)
+
+Provides verification functions:
+- Single proof verification
+- Batch verification for improved efficiency
+
+## Getting Started
+
+For a complete end-to-end example, see the `test_compute_kzg_proof` function in [prover/tests/kzg_test.rs](./prover/tests/kzg_test.rs).
+
+### EigenDA Integration
+
+To configure with the EigenDA KZG trusted setup:
+
+1. Download the G1 and G2 points from the [Operator Setup Guide](https://github.com/Layr-Labs/eigenda-operator-setup)
+2. Specify the files in `kzg.setup()` function as described in the [prover documentation](./prover/README.md)
+
+## Development
+
+### Requirements
+
+- Rust 1.75 or later
+
+### Building and Testing
+
+```bash
+# Build all crates
+cargo build
+
+# Run tests
+cargo test
+
+# Run benchmarks
+cargo bench
+```
+
+## Warning & Disclaimer
+
+This code is unaudited and under construction. This is experimental software and is provided on an "as is" and "as available" basis. It may not work as expected and should not be used in production environments.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](./LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you encounter issue running tests and it fails with the following error:
 ```
 error: package `half v2.5.0` cannot be built because it requires rustc 1.81 or newer, while the currently active rustc version is 1.75.0
 ```
-then run `cargo update half@2.5.0 --precise 2.4.1` to update this transitive dependency to a lower version.
+then run `cargo update half --precise 2.4.1` to downgrade this transitive dependency to a lower version that works with our MSRV.
 This issue can be permanently solved when [this rust RFC](https://rust-lang.github.io/rfcs/3537-msrv-resolver.html) is implemented.
 
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 # rust-kzg-bn254
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+## Description
 
-A Rust implementation of KZG polynomial commitments using the BN254 elliptic curve, designed for the Ethereum ecosystem and EigenDA rollup integrations.
-
-## Overview
-
-The Kate-Zaverucha-Goldberg (KZG) polynomial commitment scheme allows for efficient proofs that a specific value exists in a polynomial at a given point, without revealing the entire polynomial. This implementation specifically targets the BN254 elliptic curve pairing, which is widely used in various blockchain applications.
+This library offers a set of functions for generating and interacting with bn254 KZG commitments and proofs in rust, with the motivation of supporting fraud and validity proof logic in EigenDA rollup integrations.
 
 ## Crates
 
@@ -45,36 +41,34 @@ Provides verification functions:
 
 For a complete end-to-end example, see the `test_compute_kzg_proof` function in [prover/tests/kzg_test.rs](./prover/tests/kzg_test.rs).
 
-### EigenDA Integration
-
-To configure with the EigenDA KZG trusted setup:
-
-1. Download the G1 and G2 points from the [Operator Setup Guide](https://github.com/Layr-Labs/eigenda-operator-setup)
-2. Specify the files in `kzg.setup()` function as described in the [prover documentation](./prover/README.md)
-
-## Development
-
-### Requirements
-
-- Rust 1.75 or later
-
-### Building and Testing
+### Building and Benchmark
 
 ```bash
 # Build all crates
 cargo build
 
-# Run tests
-cargo test
-
 # Run benchmarks
 cargo bench
 ```
+### Compatibility
+1. The project is compatible with Rust 1.75 or later
+
+### Downstream Dependencies
+1. Arbitrum Nitro uses rust 1.78
+2. RiscZero ZKVM uses 1.85
+3. SP1 ZKVM uses 1.79
+
+
+### Notes on testing
+If you encounter issue running tests and it failes with the following error:
+```
+error: package `half v2.5.0` cannot be built because it requires rustc 1.81 or newer, while the currently active rustc version is 1.75.0
+```
+then run `cargo update half@2.5.0 --precise 2.4.1` to update this transitive dependency to a lower version.
+This issue can be permanently solved when [this rust RFC](https://rust-lang.github.io/rfcs/3537-msrv-resolver.html) is implemented.
+
+
 
 ## Warning & Disclaimer
 
 This code is unaudited and under construction. This is experimental software and is provided on an "as is" and "as available" basis. It may not work as expected and should not be used in production environments.
-
-## License
-
-This project is licensed under the MIT License - see the [LICENSE](./LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cargo bench
 
 
 ### Notes on testing
-If you encounter issue running tests and it failes with the following error:
+If you encounter issue running tests and it fails with the following error:
 ```
 error: package `half v2.5.0` cannot be built because it requires rustc 1.81 or newer, while the currently active rustc version is 1.75.0
 ```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ cargo bench
 ### Downstream Dependencies
 1. Arbitrum Nitro uses rust 1.78
 2. RiscZero ZKVM uses 1.85
-3. SP1 ZKVM uses 1.79
+3. SP1 ZKVM uses [1.79](https://github.com/succinctlabs/sp1/blob/81757da015939d8a851d909e8c3df14bdc3b030d/Cargo.toml#L5)
 
 
 ### Notes on testing

--- a/primitives/README.md
+++ b/primitives/README.md
@@ -1,5 +1,6 @@
 # rust-kzg-bn254-primitives
 
+[![Docs](https://docs.rs/rust-kzg-bn254-primitives/badge.svg)](https://docs.rs/rust-kzg-bn254-primitives/latest/rust_kzg_bn254_primitives/)
 [![Crate](https://img.shields.io/crates/v/rust-kzg-bn254-primitives.svg)](https://crates.io/crates/rust-kzg-bn254-primitives)
 
 This library offers primitive set of structures and functions for generating and interacting with bn254 KZG commitments and proofs in rust.

--- a/prover/README.md
+++ b/prover/README.md
@@ -1,4 +1,4 @@
-# rust-kzg-bn254
+# rust-kzg-bn254-prover
 
 [![Docs](https://docs.rs/rust-kzg-bn254-prover/badge.svg)](https://docs.rs/rust-kzg-bn254-prover/latest/rust_kzg_bn254_prover/)
 [![Crate](https://img.shields.io/crates/v/rust-kzg-bn254-prover.svg)](https://crates.io/crates/rust-kzg-bn254-prover)

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -1,5 +1,6 @@
 # rust-kzg-bn254-verification
 
+[![Docs](https://docs.rs/rust-kzg-bn254-verifier/badge.svg)](https://docs.rs/rust-kzg-bn254-verifier/latest/rust_kzg_bn254_verifier/)
 [![Crate](https://img.shields.io/crates/v/rust-kzg-bn254-verifier.svg)](https://crates.io/crates/rust-kzg-bn254-verifier)
 
 This library offers verification functions, including batch verification, for KZG.

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -1,4 +1,4 @@
-# rust-kzg-bn254-verification
+# rust-kzg-bn254-verifier
 
 [![Docs](https://docs.rs/rust-kzg-bn254-verifier/badge.svg)](https://docs.rs/rust-kzg-bn254-verifier/latest/rust_kzg_bn254_verifier/)
 [![Crate](https://img.shields.io/crates/v/rust-kzg-bn254-verifier.svg)](https://crates.io/crates/rust-kzg-bn254-verifier)


### PR DESCRIPTION
half, a downstream dependant library is now requiring 1.81. This only affects testing, so updating the library only during testing for it to work.