### PR TITLE
chore: bump rust msrv 1.75->1.78

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ thiserror = "2.0.11"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.78"
 repository = "https://github.com/Layr-Labs/rust-kzg-bn254"
 homepage = ""
 license-file = "LICENSE"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = '1.75'
+channel = '1.78'
 profile = 'minimal'
 components = ['clippy', 'rustfmt']
 targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "i686-unknown-linux-gnu"]


### PR DESCRIPTION
All of 3 our downstream dependencies (see README) have MSRV >= 1.78 so this is safe.
Latest rust-analyzer extension in vscode requires rust version >= 1.78, so maintaining 1.75 has become a bit painful.
Time to bump.