### PR TITLE
ci: fix crates release workflow and add docs

### DIFF
--- a/.github/workflows/crates-release-prod.yml
+++ b/.github/workflows/crates-release-prod.yml
@@ -1,7 +1,16 @@
 name: crate-release-prod
 on:
   workflow_dispatch:
-  
+    inputs:
+      crate_name:
+        description: "Crate to publish"
+        required: true
+        type: choice
+        options:
+          - rust-kzg-bn254-primitives
+          - rust-kzg-bn254-verifier
+          - rust-kzg-bn254-prover
+
 jobs:
   crates-publish:
     runs-on: ubuntu-latest
@@ -11,4 +20,4 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
       - name: Publish Crate
-        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish -p ${{ inputs.crate_name }} --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ error: package `half v2.5.0` cannot be built because it requires rustc 1.81 or n
 then run `cargo update half --precise 2.4.1` to downgrade this transitive dependency to a lower version that works with our MSRV.
 This issue can be permanently solved when [this rust RFC](https://rust-lang.github.io/rfcs/3537-msrv-resolver.html) is implemented.
 
+## Crates Releases
 
+Releasing a crate is done by creating a PR (see this [example](https://github.com/Layr-Labs/rust-kzg-bn254/pull/49)) that bumps the version in `Cargo.toml` and then [manually dispatching](https://github.com/Layr-Labs/rust-kzg-bn254/actions/workflows/crates-release-prod.yml) the [crates-release-prod.yml](./.github/workflows/crates-release-prod.yml) workflow. This will publish the new version to crates.io.
+
+```bash
 
 ## Warning & Disclaimer
 


### PR DESCRIPTION
Crates release workflow has been [failing](https://github.com/Layr-Labs/rust-kzg-bn254/actions/runs/14206283343) since we separated into workspace with multiple crates. Added an input to ci to choose the package to release. Also added README docs on how to make a release.