### PR TITLE
chore: bump primitives+verifier to 0.1.2

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-kzg-bn254-primitives"
-version = "0.1.1"
+version = "0.1.2"
 description = "This library offers a set of structs, traits and functions for generating Blobs and Polynomials which are used to interact with rust-kzg-bn254-prover and rust-kzg-bn254-verifier crates."
 edition.workspace = true
 repository.workspace = true

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-kzg-bn254-verifier"
-version = "0.1.1"
+version = "0.1.2"
 description = "This library offers a set of functions for verifying KZG commitments and proofs in bn254, with the motivation of supporting fraud and validity proof logic in EigenDA rollup integrations."
 license-file.workspace = true
 edition.workspace = true


### PR DESCRIPTION
verifier and primitives are now no-std, which was needed for hokulea