### PR TITLE
chore: downgrade libm to 0.2.8 to match sp1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ rust-kzg-bn254-verifier = { version = "0.1.1", path = "./verifier" }
 thiserror = { version = "2.0.11", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-libm = "0.2.13"
+libm = "0.2.8"
 serde = { version = "1.0.219", default-features = false }
 
 ark-bn254 = { version = "0.5.0", default-features = false }


### PR DESCRIPTION
The lib in sp1 zkvm is only up to 0.2.8, creating deps conflict. 

No sure about risc0, so no need to create a version yet