### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/crates-release-prod.yml
+++ b/.github/workflows/crates-release-prod.yml
@@ -1,4 +1,6 @@
 name: crate-release-prod
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Layr-Labs/rust-kzg-bn254/security/code-scanning/1](https://github.com/Layr-Labs/rust-kzg-bn254/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow checks out code and publishes a crate (using a secret token for crates.io), it likely only needs `contents: read` to fetch the code. If it does not interact with issues, pull requests, or other resources, no additional permissions are needed. The best way to fix this is to add a `permissions: contents: read` block at the top level of the workflow (just after the `name` or `on` block), which will apply to all jobs unless overridden. This change should be made at the top of `.github/workflows/crates-release-prod.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
