### PR TITLE
feat: srs clone-on-write

### DIFF
--- a/prover/src/srs.rs
+++ b/prover/src/srs.rs
@@ -2,9 +2,9 @@ use ark_bn254::G1Affine;
 use crossbeam_channel::{bounded, Receiver};
 use rust_kzg_bn254_primitives::errors::KzgError;
 use rust_kzg_bn254_primitives::traits::ReadPointFromBytes;
+use std::borrow::Cow;
 use std::fs::File;
 use std::io::{self, BufReader, Read};
-use std::borrow::Cow;
 
 /// Represents the Structured Reference String (SRS) used in KZG commitments.
 #[derive(Debug, PartialEq)]

--- a/prover/src/srs.rs
+++ b/prover/src/srs.rs
@@ -4,19 +4,23 @@ use rust_kzg_bn254_primitives::errors::KzgError;
 use rust_kzg_bn254_primitives::traits::ReadPointFromBytes;
 use std::fs::File;
 use std::io::{self, BufReader, Read};
+use std::borrow::Cow;
 
 /// Represents the Structured Reference String (SRS) used in KZG commitments.
-#[derive(Debug, PartialEq, Clone)]
-pub struct SRS {
+#[derive(Debug, PartialEq)]
+pub struct SRS<'a> {
     // SRS points are stored in monomial form, ready to be used for commitments with polynomials
     // in coefficient form. To commit against a polynomial in evaluation form, we need to transform
     // the SRS points to lagrange form using IFFT.
-    pub g1: Vec<G1Affine>,
+    //
+    // Uses Cow (Clone on Write) to enable zero-copy borrowing when the SRS is constructed from
+    // existing data, while still allowing owned data when needed.
+    pub g1: Cow<'a, [G1Affine]>,
     /// The order of the SRS.
     pub order: u32,
 }
 
-impl SRS {
+impl SRS<'_> {
     /// Initializes the SRS by loading G1 points from a file.
     ///
     /// # Arguments
@@ -39,7 +43,7 @@ impl SRS {
             Self::parallel_read_g1_points(path_to_g1_points.to_owned(), points_to_load, false)?;
 
         Ok(Self {
-            g1: g1_points,
+            g1: g1_points.into(),
             order,
         })
     }

--- a/prover/tests/kzg_test.rs
+++ b/prover/tests/kzg_test.rs
@@ -12,7 +12,7 @@ mod tests {
     // Define a static variable for setup
     lazy_static! {
         static ref KZG_INSTANCE: KZG = KZG::new();
-        static ref SRS_INSTANCE: SRS = SRS::new(
+        static ref SRS_INSTANCE: SRS<'static> = SRS::new(
             "tests/test-files/mainnet-data/g1.131072.point",
             268435456,
             131072

--- a/verifier/tests/tests.rs
+++ b/verifier/tests/tests.rs
@@ -17,7 +17,7 @@ mod tests {
     // Define a static variable for setup
     lazy_static! {
         static ref KZG_INSTANCE: KZG = KZG::new();
-        static ref SRS_INSTANCE: SRS = SRS::new(
+        static ref SRS_INSTANCE: SRS<'static> = SRS::new(
             "../prover/tests/test-files/mainnet-data/g1.131072.point",
             268435456,
             131072


### PR DESCRIPTION
The ability to construct an SRS struct with a slice enables a significant optimization if a fat binary is not a concern: SRS points can be directly embedded into the binary at compile time as a static slice.

Note, however, that making SRS exclusively hold a slice is not recommended, since in that case the implementation would be unable to return a new SRS since the data it references would be dropped immediately. Using Cow here is therefore ergonomic, as it supports both use cases.