### PR TITLE
fix(build): bump to rust 1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.80"
 repository = "https://github.com/Layr-Labs/rust-kzg-bn254"
 homepage = ""
 license-file = "LICENSE"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = '1.78'
+channel = '1.80'
 profile = 'minimal'
 components = ['clippy', 'rustfmt']
 targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "i686-unknown-linux-gnu"]


### PR DESCRIPTION
Build was failing because of our rayon dependency upgrade. Could have downgraded rayon but afaik all our customers are already on versions >= 1.80 (op use cases are all on 1.85/6+)